### PR TITLE
17.2 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+PHP_EXTRA_PINS=libpcre2-8-0 libgd3
+PHP_VERSION=8.1
+
 include $(FAB_PATH)/common/mk/turnkey/laravel.mk
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/changelog
+++ b/changelog
@@ -1,3 +1,11 @@
+turnkey-snipe-it-17.2 (1) turnkey; urgency=low
+
+  * Upgraded Snipe-IT: v6.0.14.
+
+  * Rebuild with PHP 8.1 - (next major version will require it).
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 23 Feb 2023 01:42:41 +0000
+
 turnkey-snipe-it-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.
@@ -12,18 +20,13 @@ turnkey-snipe-it-17.0 (1) turnkey; urgency=low
 
   * Upgraded Snipe-IT: v5.4.4
 
-  * Note: Please refer to turnkey-core's 17.0 changelog for changes common to all
-
- -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Fri, 06 May 2022 18:17:30 +0300
-
-turnkey-snipe-it-16.2 (UNRELEASED) turnkey; urgency=low
-
-  * ...
-
   * Add DOMAIN inithook - closes #1594
     [ Stefan Davis <stefan@turnkeylinux.org> ]
 
- -- Stefan Davis <stefan@turnkeylinux.org>  Thu, 12 Aug 2021 16:01:04 +1000
+  * Note: Please refer to turnkey-core's 17.0 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Fri, 06 May 2022 18:17:30 +0300
 
 turnkey-snipe-it-16.1 (1) turnkey; urgency=low
 

--- a/plan/main
+++ b/plan/main
@@ -1,15 +1,15 @@
 #include <turnkey/base>
-#include <turnkey/lamp>
+#include <turnkey/lamp81>
 
 python3-bcrypt
 
-php-curl
-php-json
-php-mbstring
-php-gd
-php-ldap
-php-zip
-php-bcmath
-php-xml
+php8.1-curl
+php8.1-json
+php8.1-mbstring
+php8.1-gd
+php8.1-ldap
+php8.1-zip
+php8.1-bcmath
+php8.1-xml
 
 unzip


### PR DESCRIPTION
This is a maintenance build for Snipe-IT.

It's fairly minor with a bump to the Snipe-IT version (the build code tries to install the latest, so no code changes for that). I have also installed php8.1. The current v6.0.x doesn't require it, but the next release (I assume they mean v6.1.x) will need PHP >= 8.0. I also tidied the changelog up a little.